### PR TITLE
fix: 🐛 Font-size of Message Valid in Let's Start Page

### DIFF
--- a/src/components/lets-start/style.module.scss
+++ b/src/components/lets-start/style.module.scss
@@ -29,7 +29,7 @@
   .abc-input.error {
     @apply relative;
     .message {
-      @apply absolute left-0 mt-0;
+      @apply absolute left-0 mt-0 text-xs;
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Screenshots or videos

## Checklist before requesting a review

- [ ] Test UI on desktop, tablet, mobile.
- [ ] Check source code to make sure that those codes and files are correct.
- [ ] Remove debug code.
- [ ] Remove redundant space chars.
- [ ] Check for special characters when copying from elsewhere. (Mostly ‘ and -) You should retype.
- [ ] Add 1 line at the end of the file.
- [ ] Format code.
- [ ] Image should be JPG and filesize should be below 300kb, video should be WEBM or MP4 and filesize below 5mb.
- [ ] Priority using the Google Fonts, if using Local Fonts, the file type should be TTF or WOFF.
