### PR TITLE
fix: 🐛 [FE] Page Let Start: Giảm padding 32->24

### DIFF
--- a/src/components/lets-start/style.module.scss
+++ b/src/components/lets-start/style.module.scss
@@ -24,7 +24,7 @@
     @apply px-4;
   }
   .abc-btn {
-    @apply mt-4 md:mt-8;
+    @apply mt-4 md:mt-6;
   }
   .abc-input.error {
     @apply relative;


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Screenshots or videos
- Bug:
![image](https://user-images.githubusercontent.com/110363738/190352036-8ad671b5-df8e-4021-a886-cda9a7ee84bb.png)

- Fix:
![image](https://user-images.githubusercontent.com/110363738/190352067-044a3e4e-a992-4fac-a987-da683e48cd0c.png)

## Checklist before requesting a review

- [ ] Test UI on desktop, tablet, mobile.
- [ ] Check source code to make sure that those codes and files are correct.
- [ ] Remove debug code.
- [ ] Remove redundant space chars.
- [ ] Check for special characters when copying from elsewhere. (Mostly ‘ and -) You should retype.
- [x] Add 1 line at the end of the file.
- [x] Format code.
- [ ] Image should be JPG and filesize should be below 300kb, video should be WEBM or MP4 and filesize below 5mb.
- [ ] Priority using the Google Fonts, if using Local Fonts, the file type should be TTF or WOFF.
