### PR TITLE
fix: 🐛 [FE]: Font size chart label from 32px to 24px

### DIFF
--- a/src/core-ui/doughnut-chart/index.tsx
+++ b/src/core-ui/doughnut-chart/index.tsx
@@ -35,7 +35,7 @@ const DoughnutChart: FC<IProps> = ({className, votedData}) => {
               textAlign: 'center',
               weight: 'bold',
               font: {
-                size: 32,
+                size: 24,
                 lineHeight: 3,
                 family: 'Mulish'
               }


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Screenshots or videos
- Fix:
![image](https://user-images.githubusercontent.com/110363738/190942078-5ed40584-c3bf-4989-91b6-58927b108fef.png)

## Checklist before requesting a review

- [ ] Test UI on desktop, tablet, mobile.
- [ ] Check source code to make sure that those codes and files are correct.
- [ ] Remove debug code.
- [ ] Remove redundant space chars.
- [ ] Check for special characters when copying from elsewhere. (Mostly ‘ and -) You should retype.
- [x] Add 1 line at the end of the file.
- [x] Format code.
- [ ] Image should be JPG and filesize should be below 300kb, video should be WEBM or MP4 and filesize below 5mb.
- [ ] Priority using the Google Fonts, if using Local Fonts, the file type should be TTF or WOFF.
