### PR TITLE
fix: 🐛 Page Let Start: Nhập quá 32 ký tự sẽ không cho nhập nữa

### DIFF
--- a/src/components/lets-start/index.tsx
+++ b/src/components/lets-start/index.tsx
@@ -23,7 +23,12 @@ const LetsStart: React.FC = () => {
                   <Heading className="head-form" as="h4">
                     Let&apos;s start!
                   </Heading>
-                  <Input error={errors.name?.message} placeholder="Enter your name" {...register('name')} />
+                  <Input
+                    error={errors.name?.message}
+                    placeholder="Enter your name"
+                    maxLength={32}
+                    {...register('name')}
+                  />
                   <Button className="w-full" variant="contained" color="primary" type="submit">
                     Enter
                   </Button>

--- a/src/components/lobby/modal-room/index.tsx
+++ b/src/components/lobby/modal-room/index.tsx
@@ -31,6 +31,7 @@ const ModalRoom: FC<IProps> = ({open, setOpen}) => {
                       error={errors.name?.message}
                       className={errors.name && 'error'}
                       placeholder="Enter room name"
+                      maxLength={32}
                       {...register('name')}
                     />
                   </div>


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Screenshots or videos
- Fix:
![image](https://user-images.githubusercontent.com/110363738/190994357-9d9161eb-99b8-44f5-ad97-8ab3e11b24f2.png)

![image](https://user-images.githubusercontent.com/110363738/190994405-38a4ba71-90d8-4866-8e39-2d8155cac7ad.png)

## Checklist before requesting a review

- [ ] Test UI on desktop, tablet, mobile.
- [ ] Check source code to make sure that those codes and files are correct.
- [ ] Remove debug code.
- [ ] Remove redundant space chars.
- [ ] Check for special characters when copying from elsewhere. (Mostly ‘ and -) You should retype.
- [x] Add 1 line at the end of the file.
- [x] Format code.
- [ ] Image should be JPG and filesize should be below 300kb, video should be WEBM or MP4 and filesize below 5mb.
- [ ] Priority using the Google Fonts, if using Local Fonts, the file type should be TTF or WOFF.
