### PR TITLE
fix: 🐛 Add maxLength to input page let's start and modal create room

### DIFF
--- a/src/components/lets-start/index.tsx
+++ b/src/components/lets-start/index.tsx
@@ -23,7 +23,12 @@ const LetsStart: React.FC = () => {
                   <Heading className="head-form" as="h4">
                     Let&apos;s start!
                   </Heading>
-                  <Input error={errors.name?.message} placeholder="Enter your name" {...register('name')} />
+                  <Input
+                    error={errors.name?.message}
+                    placeholder="Enter your name"
+                    maxLength={33}
+                    {...register('name')}
+                  />
                   <Button className="w-full" variant="contained" color="primary" type="submit">
                     Enter
                   </Button>

--- a/src/components/lobby/modal-room/index.tsx
+++ b/src/components/lobby/modal-room/index.tsx
@@ -31,6 +31,7 @@ const ModalRoom: FC<IProps> = ({open, setOpen}) => {
                       error={errors.name?.message}
                       className={errors.name && 'error'}
                       placeholder="Enter room name"
+                      maxLength={33}
                       {...register('name')}
                     />
                   </div>


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Screenshots or videos
- Fix:
![image](https://user-images.githubusercontent.com/110363738/191212989-ee3d656e-aca6-43a0-8bd9-8f26d45bf1e7.png)

![image](https://user-images.githubusercontent.com/110363738/191213061-b6969793-9b11-45c2-88a4-e7333ece4a73.png)

## Checklist before requesting a review

- [ ] Test UI on desktop, tablet, mobile.
- [ ] Check source code to make sure that those codes and files are correct.
- [ ] Remove debug code.
- [ ] Remove redundant space chars.
- [ ] Check for special characters when copying from elsewhere. (Mostly ‘ and -) You should retype.
- [x] Add 1 line at the end of the file.
- [x] Format code.
- [ ] Image should be JPG and filesize should be below 300kb, video should be WEBM or MP4 and filesize below 5mb.
- [ ] Priority using the Google Fonts, if using Local Fonts, the file type should be TTF or WOFF.
