### PR TITLE
fix: 🐛 PLAN-176: Tên phòng bị lệch so với mũi tên

### DIFF
--- a/src/components/voting/style.module.scss
+++ b/src/components/voting/style.module.scss
@@ -16,7 +16,7 @@
       @apply text-right;
     }
     .room-name {
-      @apply -mt-1 break-words text-h4 font-bold leading-5 md:text-h3;
+      @apply mt-1 break-words text-h4 font-bold leading-5 md:-mt-[2px] md:text-h3;
     }
     .left {
       @apply flex items-start;


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Screenshots or videos
- Bug:
![image](https://user-images.githubusercontent.com/110363738/191884777-0dbb8be9-4f7c-491f-b063-39eaff1074d5.png)

- Fix:
desktop:
![image](https://user-images.githubusercontent.com/110363738/191884886-c94d9f36-ca29-4dd0-bd27-0f071d0919a4.png)

tablet:
![image](https://user-images.githubusercontent.com/110363738/191884908-087b8570-7879-4342-835d-eb1badba6b46.png)

mobile:
![image](https://user-images.githubusercontent.com/110363738/191884938-7d47c70c-a753-4fc0-80b6-963022658926.png)


## Checklist before requesting a review

- [ ] Test UI on desktop, tablet, mobile.
- [ ] Check source code to make sure that those codes and files are correct.
- [ ] Remove debug code.
- [ ] Remove redundant space chars.
- [ ] Check for special characters when copying from elsewhere. (Mostly ‘ and -) You should retype.
- [x] Add 1 line at the end of the file.
- [x] Format code.
- [ ] Image should be JPG and filesize should be below 300kb, video should be WEBM or MP4 and filesize below 5mb.
- [ ] Priority using the Google Fonts, if using Local Fonts, the file type should be TTF or WOFF.
